### PR TITLE
fix(dolt): use real titles and add superblocks_blocks data

### DIFF
--- a/dolt/dashed-names-to-titles.js
+++ b/dolt/dashed-names-to-titles.js
@@ -1,0 +1,26 @@
+import { readFileSync } from 'fs';
+
+let introJson = {};
+
+try {
+  const jsonData = readFileSync(
+    '../client/i18n/locales/english/intro.json',
+    'utf8'
+  );
+  introJson = JSON.parse(jsonData);
+  delete introJson['misc-text'];
+} catch (error) {
+  console.error('Error reading file:', error);
+}
+
+const flatBlocks = Object.values(introJson).reduce((allBlocks, superblock) => {
+  return { ...allBlocks, ...superblock.blocks };
+}, {});
+
+export const getSuperblockTitle = dashedName => {
+  return introJson[dashedName].title;
+};
+
+export const getBlockTitle = dashedName => {
+  return flatBlocks[dashedName].title;
+};


### PR DESCRIPTION
The superblocks_blocks data wasn't being added. This fixes that. 

Also, it gets the real titles for superblocks and blocks from the intro.json file.

Here's a query to see the data after seeding:

`SELECT s.title, b.title, superblock_order, block_order FROM superblocks AS s FULL JOIN superblocks_blocks AS sb ON s.id = sb.superblock_id FULL JOIN blocks AS b ON b.id = sb.block_id ORDER BY superblock_order, block_order;`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
