### PR TITLE
feat: start to create endpoint that reproduces getChallengesForLang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ curriculum/build
 ### Dolt ###
 .sqlhistory
 .dolt*
+dolt/api/curriculum.json
+dolt/api/learn-curriculum.json
+dolt/api/mobile-curriculum.json

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -1,5 +1,6 @@
 const path = require('path');
-
+// uncomment if you want to write the learn-curriculum.json file below
+// const { writeFileSync } = require('fs');
 const _ = require('lodash');
 
 const envData = require('../config/env.json');
@@ -38,6 +39,8 @@ exports.replaceChallengeNode = () => {
 
 exports.buildChallenges = async function buildChallenges() {
   const curriculum = await getChallengesForLang(curriculumLocale);
+  // uncomment to write the learn-curriculum.json file in dolt/api
+  // writeFileSync(`../dolt/api/learn-curriculum.json`, JSON.stringify(curriculum, null, 2));
   const superBlocks = Object.keys(curriculum);
   const blocks = superBlocks
     .map(superBlock => curriculum[superBlock].blocks)

--- a/dolt/api/curriculum.test.js
+++ b/dolt/api/curriculum.test.js
@@ -1,0 +1,50 @@
+const { readFileSync } = require('fs');
+
+const newCurriculumFile = readFileSync('./curriculum.json', 'utf8');
+const oldCurriculumFile = readFileSync('./learn-curriculum.json', 'utf8');
+const newCurriculum = JSON.parse(newCurriculumFile);
+const oldCurriculum = JSON.parse(oldCurriculumFile);
+
+const superblocks = Object.keys(newCurriculum);
+
+function lowerCaseChallengeOrder(challengeOrder) {
+  return challengeOrder.map(({ id, title }) => {
+    return { id, title: title.toLowerCase() };
+  });
+}
+
+describe('curriculum', () => {
+  superblocks.forEach(superblock => {
+    const blocks = Object.keys(newCurriculum[superblock].blocks);
+
+    blocks.forEach(block => {
+      // meta stuff
+      const newBlockMeta = newCurriculum[superblock].blocks[block].meta;
+      const oldBlockMeta = oldCurriculum[superblock].blocks[block].meta;
+
+      // just ignoring the name field for now. Uncomment to see ones that don't match
+      newBlockMeta.name = '';
+      oldBlockMeta.name = '';
+
+      // making the titles in challengeOrder lowercase for now. Uncomment to see more fails
+      newBlockMeta.challengeOrder = lowerCaseChallengeOrder(
+        newBlockMeta.challengeOrder
+      );
+      oldBlockMeta.challengeOrder = lowerCaseChallengeOrder(
+        oldBlockMeta.challengeOrder
+      );
+
+      it(`${superblock} : ${block} should have the same meta`, () => {
+        expect(newBlockMeta).toEqual(oldBlockMeta);
+      });
+
+      // challenges stuff
+      // const newBlockChallenges = newCurriculum[superblock].blocks[block].challenges;
+      // const oldBlockChallenges = oldCurriculum[superblock].blocks[block].challenges;
+
+      // it(`${superblock} : ${block} should have the same challenges`, () => {
+      //   expect(newBlockChallenges).toEqual(oldBlockChallenges);
+      // });
+    });
+  });
+});

--- a/dolt/api/variables.js
+++ b/dolt/api/variables.js
@@ -6,6 +6,7 @@ const tables = {
   bilibili_ids: 'bilibili_ids',
   block_time_to_complete: 'block_time_to_complete',
   blocks_challenges: 'blocks_challenges',
+  block_is_upcoming_change: 'block_is_upcoming_change',
   certifications_prerequisites: 'certifications_prerequisites',
   challenge_files: 'challenge_files',
   challenge_type: 'challenge_type',
@@ -32,6 +33,7 @@ const tables = {
   template: 'template',
   tests: 'tests',
   title: 'title',
+  uses_multifile_editor: 'uses_multifile_editor',
   video_id: 'video_id',
   video_locale_ids: 'video_locale_ids',
   video_url: 'video_url',
@@ -41,37 +43,38 @@ const tables = {
   superblocks: 'superblocks'
 };
 
-// challenge feature tables with an identifying column in the table
+// challenge feature tables with an identifying column in the table,
+// column name in that table on the right
 export const featureTablesWithColumns = {
-  [tables.assignments]: ['assignments'],
-  [tables.audio_path]: ['audioPath'],
-  [tables.bilibili_ids]: ['bilibiliIds'],
+  [tables.assignments]: 'assignments',
+  [tables.audio_path]: 'audioPath',
+  [tables.bilibili_ids]: 'bilibiliIds',
   // [tables.block_time_to_complete]: [],
   // [tables.blocks_challenges]: [],
   // [tables.certifications_prerequisites]: [],
-  [tables.challenge_files]: ['challengeFiles'],
-  [tables.challenge_type]: ['challengeType'],
-  [tables.course_url]: ['course_url'],
-  [tables.descriptions]: ['descriptions'],
-  [tables.fill_in_the_blank]: ['fillInTheBlank'],
-  [tables.forum_topic_id]: ['forumTopicId'],
-  [tables.help_category]: ['helpCategory'],
-  [tables.instructions]: ['instructions'],
+  [tables.challenge_files]: 'challengeFiles',
+  [tables.challenge_type]: 'challengeType',
+  [tables.course_url]: 'course_url',
+  [tables.descriptions]: 'descriptions',
+  [tables.fill_in_the_blank]: 'fillInTheBlank',
+  [tables.forum_topic_id]: 'forumTopicId',
+  [tables.help_category]: 'helpCategory',
+  [tables.instructions]: 'instructions',
   // [tables.local_address_allowed]: [],
-  [tables.ms_trophy_id]: ['msTrophyId'],
-  [tables.notes]: ['notes'],
-  [tables.prerequisites]: ['prerequisites'],
-  [tables.question]: ['question'],
-  [tables.required_resources]: ['required_resources'],
-  [tables.scene]: ['scene'],
-  [tables.solutions]: ['solutions'],
+  [tables.ms_trophy_id]: 'msTrophyId',
+  [tables.notes]: 'notes',
+  [tables.prerequisites]: 'prerequisites',
+  [tables.question]: 'question',
+  [tables.required_resources]: 'required_resources',
+  [tables.scene]: 'scene',
+  [tables.solutions]: 'solutions',
   // [tables.superblocks_blocks]: [],
-  [tables.template]: ['template'],
-  [tables.tests]: ['tests'],
-  [tables.title]: ['title'],
-  [tables.video_id]: ['videoId'],
-  [tables.video_locale_ids]: ['videoLocaleIds'],
-  [tables.video_url]: ['videoUrl']
+  [tables.template]: 'template',
+  [tables.tests]: 'tests',
+  [tables.title]: 'title',
+  [tables.video_id]: 'videoId',
+  [tables.video_locale_ids]: 'videoLocaleIds',
+  [tables.video_url]: 'videoUrl'
   // [tables.challenges]: [],
   // [tables.blocks]: [],
   // [tables.certifications]: [],
@@ -91,7 +94,8 @@ export const booleanFeatureTables = {
   [tables.disable_loop_protect_tests]: 'disableLoopProtectTests',
   [tables.display_preview_modal]: 'displayPreviewModal',
   [tables.editor_address_allowed]: 'editorAddressAllowed',
-  [tables.local_address_allowed]: 'localAddressAllowed'
+  [tables.local_address_allowed]: 'localAddressAllowed',
+  [tables.uses_multifile_editor]: 'usesMultifileEditor'
 };
 
 // should probably track the columns instead, but this works for now
@@ -119,5 +123,6 @@ export const columnsToGraphqlName = {
   challenge_files: 'challengeFiles',
   fill_in_the_blank: 'fillInTheBlank',
   prerequisites: 'prerequisites',
+  required_resources: 'required',
   question: 'question'
 };

--- a/tools/challenge-parser/parser/index.js
+++ b/tools/challenge-parser/parser/index.js
@@ -22,7 +22,7 @@ const tableAndStrikeThrough = require('./plugins/table-and-strikethrough');
 const addScene = require('./plugins/add-scene');
 
 // set this to true to parse the challenges for seeding the dolt database
-const parseForSeedingDoltDb = true;
+const parseForSeedingDoltDb = false;
 let processor;
 
 if (parseForSeedingDoltDb) {

--- a/tools/scripts/build/build-curriculum.ts
+++ b/tools/scripts/build/build-curriculum.ts
@@ -14,6 +14,8 @@ const globalConfigPath = path.resolve(__dirname, '../../../shared/config');
 // across all languages.
 void getChallengesForLang('english')
   .then((result: Record<string, unknown>) => {
+    // uncomment to write the mobile-curriculum.json file in dolt/api
+    // fs.writeFileSync(`../dolt/api/mobile-curriculum.json`, JSON.stringify(result, null, 2));
     buildExtCurriculumData('v1', result as Curriculum<CurriculumProps>);
     return result;
   })


### PR DESCRIPTION
This is a start to creating an endpoint that reproduces what the `getChallengesForLang` function returns that both learn and mobile use to build. The goal is to get the endpoint to produce the same thing that the function does. There's a curriculum.test.js file to test the difference between the two. You need to create the json files it is looking for first. To do that, uncomment the things in build-challenges.js, build-curriculum.ts, and dolt/api/index.js files to write the files. Build the main client to write the first two JSON files, start the API to write the file for that. Then you can run the curriculum.test.js file to test them against each other.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
